### PR TITLE
Fix handbook manifest to allow for importing

### DIFF
--- a/bin/sustainability-manifest.json
+++ b/bin/sustainability-manifest.json
@@ -1,9 +1,9 @@
 {
   "index": {
     "title": "Sustainability Handbook",
-    "slug": null,
-    "markdown_source": "https:\/\/github.com\/wordpress\/sustainability-handbook\/blob\/master\/index.md",
-    "parent": null
+    "slug": "handbook",
+    "markdown_source": "https:\/\/github.com\/wordpress\/sustainability\/blob\/trunk\/index.md",
+    "parent": null,
     "order": -1
   }
 }


### PR DESCRIPTION
- Supply a slug value of "handbook" to the root page so it is recognized as the root page of the handbook
- Fix 'markdown_source' path to reference the correct repo name and branch
- Add missing comma after 'parent' entry